### PR TITLE
fix: set range

### DIFF
--- a/dboot/SubSystem/ProgressDialog.cs
+++ b/dboot/SubSystem/ProgressDialog.cs
@@ -828,6 +828,7 @@ namespace dboot.SubSystem
                 if (!_progressBarHandle.IsNull && !Marquee)
                 {
                     // without this the progress bar will NOT update after dialoging the marquee
+                    PInvoke.SendMessage(_progressBarHandle, PBM_SETRANGE, 0, PInvoke.MAKELPARAM(0, (ushort)_maximum));
                     PInvoke.SendMessage(_progressBarHandle, PBM_SETPOS, PInvoke.MAKEWPARAM((ushort)_value, 0), 0);
                 }
             }


### PR DESCRIPTION
Just for complete we call PBM_SETRANGE to ensure the progress bar has a maximum set. I believe IProgressDialog is doing this internally (even if it ignores us) since everything work, but just to be sure. 